### PR TITLE
fix: delay on certain keymaps

### DIFF
--- a/lua/store/ui/list.lua
+++ b/lua/store/ui/list.lua
@@ -198,6 +198,7 @@ function ListWindow:_create_buffer()
       buffer = buf_id,
       silent = true,
       desc = "Store.nvim list window: " .. lhs,
+      nowait = true,
     })
   end
 

--- a/lua/store/ui/preview.lua
+++ b/lua/store/ui/preview.lua
@@ -162,6 +162,7 @@ function PreviewWindow:_create_buffer()
       buffer = buf_id,
       silent = true,
       desc = "Store.nvim preview window: " .. lhs,
+      nowait = true,
     })
   end
 


### PR DESCRIPTION
If you have a mapping for `qq` for instance, there will be a delay when closing the window. Using `nowait` fixes that.