### PR TITLE
Add auto installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A Neovim plugin for browsing and discovering awesome Neovim plugins through an i
 {
   "alex-popov-tech/store.nvim",
   dependencies = {
+    "wwingyou/lazy-install.nvim", -- for auto install
     "OXY2DEV/markview.nvim", -- optional, for pretty readme preview / help window
   },
   cmd = "Store",

--- a/lua/store/config.lua
+++ b/lua/store/config.lua
@@ -72,6 +72,7 @@ local DEFAULT_USER_CONFIG = {
     open = { "<cr>", "o" },
     switch_focus = { "<tab>", "<s-tab>" },
     sort = { "s" },
+    install = { "i" },
   },
 
   -- Behavior

--- a/lua/store/keymaps.lua
+++ b/lua/store/keymaps.lua
@@ -12,6 +12,7 @@ local descriptions = {
   open = "store.nvim - Open repository in browser",
   switch_focus = "store.nvim - Switch focus between panes",
   sort = "store.nvim - Sort repositories",
+  intsall = "store.nvim - Install plugin",
 }
 
 -- Handler functions for each action
@@ -130,6 +131,12 @@ local handlers = {
       end,
     })
   end,
+
+  install = function(instance)
+    local html_url = instance.state.current_repository.html_url
+    vim.cmd([[q]])
+    require'lazy-install'.install(html_url)
+  end,
 }
 
 -- Private function to create keymap applier for specific actions
@@ -165,14 +172,14 @@ end
 ---@param instance StoreModal Modal instance
 ---@return fun(buf_id: number) Function to apply list keymaps to buffer
 function M.make_keymaps_for_list(instance)
-  return make_keymaps_for_actions(instance, { "close", "help", "switch_focus", "filter", "refresh", "sort", "open" })
+  return make_keymaps_for_actions(instance, { "close", "help", "switch_focus", "filter", "refresh", "sort", "open", "install" })
 end
 
 -- Public function to create keymap applier for preview component
 ---@param instance StoreModal Modal instance
 ---@return fun(buf_id: number) Function to apply preview keymaps to buffer
 function M.make_keymaps_for_preview(instance)
-  return make_keymaps_for_actions(instance, { "close", "help", "switch_focus", "filter", "refresh", "sort" })
+  return make_keymaps_for_actions(instance, { "close", "help", "switch_focus", "filter", "refresh", "sort", "install" })
 end
 
 return M

--- a/lua/store/ui/help.lua
+++ b/lua/store/ui/help.lua
@@ -26,6 +26,7 @@ local help_items = {
   { keybinding = "<Esc>", action = "Close modal" },
   { keybinding = "<Tab>", action = "Switch focus" },
   { keybinding = "?", action = "Show help" },
+  { keybinding = "i", action = "Install plugin" },
 }
 
 ---Calculate column widths for help content


### PR DESCRIPTION
Hey! I just attached auto installation feature on you plugin with my simple install plugin for lazy.nvim.

https://github.com/wwingyou/lazy-install.nvim

It parse README of repo and find installation codeblock, and create lazy.nvim plugin file for it.

You can install plugin in the list view with 'i' key.

Please check it out and give me your opinion.