### PR TITLE
fix: correct lazy.nvim lockfile path

### DIFF
--- a/lua/store/ui/hover/init.lua
+++ b/lua/store/ui/hover/init.lua
@@ -159,7 +159,7 @@ function Hover:show()
     callback = function()
       vim.defer_fn(function()
         close_hover()
-        vim.api.nvim_del_augroup_by_id(group)
+        pcall(vim.api.nvim_del_augroup_by_id, group)
       end, 10)
     end,
   })

--- a/lua/store/utils.lua
+++ b/lua/store/utils.lua
@@ -622,8 +622,9 @@ local function collect_lazy_plugins(logger)
     error = nil,
   }
 
-  local config_path = vim.fn.stdpath("config")
-  local lazy_lock_path = config_path .. "/lazy-lock.json"
+  local lazy_lock_path = vim.F.npcall(function()
+    return require("lazy.core.config").options.lockfile
+  end) or (vim.fn.stdpath("config") .. "/lazy-lock.json")
 
   if vim.fn.filereadable(lazy_lock_path) == 0 then
     snapshot.error = "lazy-lock.json not found at: " .. lazy_lock_path


### PR DESCRIPTION
Use lockfile from config.

It's also possible user don't use lockfile at all / something like `/dev/null`
But fine for me now.
